### PR TITLE
reverse bind/connect logic on ZMQ socket for more appropriate client server model

### DIFF
--- a/mod_log_zmq.c
+++ b/mod_log_zmq.c
@@ -1907,9 +1907,9 @@ if (pr_netaddr_use_ipv6()) {
     pr_signals_handle();
 
     addr = c->argv[0];
-    if (zsocket_bind(zsock, addr) < 0) {
+    if (zsocket_connect(zsock, addr) < 0) {
       (void) pr_log_writefile(log_zmq_logfd, MOD_LOG_ZMQ_VERSION,
-        "error binding to LogZMQEndpoint '%s': %s", addr,
+        "error connecting to LogZMQEndpoint '%s': %s", addr,
         zmq_strerror(zmq_errno()));
       c = find_config_next(c, c->next, CONF_PARAM, "LogZMQEndpoint", FALSE);
       continue;

--- a/mod_log_zmq.html
+++ b/mod_log_zmq.html
@@ -85,7 +85,7 @@ For more information on the different ZeroMQ socket types, see:
 
 <p>
 The <code>LogZMQEndpoint</code> directive configures the <em>address</em> (as
-formatted according to <a href="http://api.zeromq.org/2-1:zmq-bind"><code>zmq_bind</code></a> specifications) to which to send a logging record, the
+formatted according to <a href="http://api.zeromq.org/2-1:zmq-connect"><code>zmq_bind</code></a> specifications) to which to send a logging record, the
 <code>LogFormat</code> <em>format-name</em> to use for the record for that
 address.
 

--- a/t/bin/zsocket.pl
+++ b/t/bin/zsocket.pl
@@ -22,8 +22,8 @@ if ($sock_type == ZMQ_SUB) {
   zmq_setsockopt($sock, ZMQ_SUBSCRIBE, "");
 }
 
-if (zmq_connect($sock, $addr)) {
-  die("Can't connect ZMQ socket to $addr: $!");
+if (zmq_bind($sock, $addr)) {
+  die("Can't bind ZMQ socket to $addr: $!");
 }
 
 print STDOUT "waiting to receive message\n";

--- a/t/lib/ProFTPD/Tests/Modules/mod_log_zmq.pm
+++ b/t/lib/ProFTPD/Tests/Modules/mod_log_zmq.pm
@@ -96,7 +96,7 @@ sub log_zmq_list {
   LogZMQDeliveryMode guaranteed
   LogZMQEngine on
   LogZMQLog $log_file
-  LogZMQEndpoint tcp://*:7777 custom
+  LogZMQEndpoint tcp://localhost:7777 custom
 </IfModule>
 EOC
     unless (close($fh)) {


### PR DESCRIPTION
I think we need reverse bind/connect logic on ZMQ socket for more appropriate client server model - some log server _bind_ to socket, and clients (proftpd) _connect_ to it.
This little patch make this little change.
